### PR TITLE
Remove trimming of trailing slashes in found urls

### DIFF
--- a/src-tauri/src/domain_crawler/helpers/links_selector.rs
+++ b/src-tauri/src/domain_crawler/helpers/links_selector.rs
@@ -64,9 +64,8 @@ fn validate_and_normalize_url(base_url: &Url, url: &Url) -> Option<Url> {
         return None; // Skip URLs from external domains
     }
 
-    // Normalize the URL by removing trailing slashes and fragment identifiers
+    // Normalize the URL by removing fragment identifiers
     let mut normalized_url = url.clone();
-    normalized_url.set_path(url.path().trim_end_matches('/'));
     normalized_url.set_fragment(None); // Remove fragment identifier
 
     Some(normalized_url)


### PR DESCRIPTION
Trailing slashes should not be trimmed, as this can cause issues for pages that use a trailing slash and do not forward the URL without the slash (which is not necessary).