### PR TITLE
Use correct attribute for page title length check

### DIFF
--- a/app/global/_components/Sidebar/Issues/IssuesContainer.tsx
+++ b/app/global/_components/Sidebar/Issues/IssuesContainer.tsx
@@ -76,11 +76,11 @@ const IssuesContainer = () => {
   const response404 = useResponseCodes(crawlData, 404);
   const response5xx = useResponseCodes(crawlData, 500);
   const pagetitleBelow30Chars = useMemo(
-    () => crawlData?.filter((page) => page?.title?.length < 30) || [],
+    () => crawlData?.filter((page) => page?.title[0]?.title?.length < 30) || [],
     [crawlData],
   );
   const pageTitlesAbove60Chars = useMemo(
-    () => crawlData?.filter((page) => page?.title?.length > 60) || [],
+    () => crawlData?.filter((page) => page?.title[0]?.title?.length > 60) || [],
     [crawlData],
   );
   const lowContentPages = useMemo(


### PR DESCRIPTION
The page title is not accessible via `page?.title?.length`, instead `page?.title[0]?.title?.length` is correct.
Without this fix all found pages are reported to have a page title below 30 chars, even if they have a longer one, and no page is reported to have more than 60 chars, even if a page has more than 60.