### PR TITLE
fix: enable text selection app-wide (closes #43)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,19 +17,34 @@
   /* Add more status codes as needed */
 }
 
-* {
+body {
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+
+.not-selectable,
+button,
+[role="button"] {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
   user-select: none;
 }
 
-.not-selectable {
-  -webkit-user-select: none;
-  /* Safari */
-  -moz-user-select: none;
-  /* Firefox */
-  -ms-user-select: none;
-  /* IE/Edge */
-  user-select: none;
-  /* Standard syntax */
+/* Re-enable selection inside virtualized table bodies. Their scroll
+   containers carry .not-selectable (to keep drag-resize clean), but
+   the actual row content lives in .domainCrawlParent and must remain
+   copyable. */
+.domainCrawlParent,
+.domainCrawlParent *,
+.selectable,
+.selectable * {
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- Removes the global `* { user-select: none }` rule in `app/globals.css` that was disabling text selection across the entire app — users couldn't copy URLs, page titles, or meta descriptions from crawl results, nor select widget content on the dashboard.
- Flips the default to `user-select: text` and uses the existing `.not-selectable` class as the explicit opt-out for chrome surfaces (sidebar, table sort-headers, sticky toolbars), which the codebase was already tagging.
- Adds `<button>` and `[role="button"]` to the non-selectable rule so click targets don't highlight.
- Re-enables selection inside the virtualized table row container `.domainCrawlParent`, since its scroll-container parent carries `.not-selectable` (intentionally, for clean column drag-resize behavior).

Fixes [#43](https://github.com/mascanho/RustySEO/issues/43).

## Notes for review
I was only able to test this in the browser (`npm run dev`) — I didn't have the local Tauri toolchain set up to compile the desktop binary. Could a maintainer please verify the fix inside `tauri dev` / a packaged build to confirm the macOS WebKit webview behaves the same way? Specifically:
- Selection works in crawl-result tables and dashboard widgets.
- Column drag-resize doesn't pick up rogue text selection mid-drag.
- Chrome surfaces (sidebar, sort-headers) and buttons remain non-selectable.